### PR TITLE
Removed deprecation warning from css-arrow

### DIFF
--- a/css-arrow/_css-arrow.sass
+++ b/css-arrow/_css-arrow.sass
@@ -4,68 +4,58 @@
 // Works only on elements with relative positioning and overflow not hidden.
 //
 // [1]: http://nicolasgallagher.com/demo/pure-css-speech-bubbles/bubbles.html
-// 
-// 
+//
+//
 
-
-= arrow( $direction, $bg-color, $border-color, $border-width, $top, $left, $width = 10px )
+=arrow($direction, $bg-color, $border-color, $border-width, $top, $left, $width: 10px)
   position: relative
   &:before
     content: "\00a0"
     // reduce the damage in FF3.0:
-    display: block 
+    display: block
     position: absolute
     width: 0
     height: 0
-
-    top: $top 
-    left: $left 
+    top: $top
+    left: $left
     bottom: auto
     border-width: floor($width / 2)
     border-style: solid
-
-    @if $direction == 'south'
+    @if $direction == "south"
       border-color: $border-color transparent transparent transparent
-    @if $direction == 'north'
+    @if $direction == "north"
       border-color: transparent transparent $border-color transparent
-    @if $direction == 'east'
+    @if $direction == "east"
       border-color: transparent transparent transparent $border-color
-    @if $direction == 'west'
+    @if $direction == "west"
       border-color: transparent $border-color transparent transparent
-
-
   // creates the smaller  triangle
   &:after
     content: "\00a0"
-    display: block 
-
+    display: block
     position: absolute
     width: 0
     height: 0
-
-    @if $direction == 'south'
+    @if $direction == "south"
       top: $top - $border-width
-    @else if $direction == 'north'
+    @else if $direction == "north"
       top: $top + $border-width
     @else
       top: $top
-
-    @if $direction == 'east'
+    @if $direction == "east"
       left: $left - $border-width
-    @else if $direction == 'west'
+    @else if $direction == "west"
       left: $left + $border-width
     @else
       left: $left
-
     bottom: auto
     border-width: floor($width / 2)
     border-style: solid
-
-    @if $direction == 'south'
+    @if $direction == "south"
       border-color: $bg-color transparent transparent transparent
-    @if $direction == 'north'
+    @if $direction == "north"
       border-color: transparent transparent $bg-color transparent
-    @if $direction == 'east'
+    @if $direction == "east"
       border-color: transparent transparent transparent $bg-color
-    @if $direction == 'west'
+    @if $direction == "west"
       border-color: transparent $bg-color transparent transparent

--- a/css-arrow/css-arrow-example.css
+++ b/css-arrow/css-arrow-example.css
@@ -18,7 +18,7 @@ body {
   margin-right: 50px;
   position: relative;
 }
-/* line 13, _css-arrow.sass */
+/* line 12, _css-arrow.sass */
 .arrow.east:before {
   content: "\00a0";
   display: block;
@@ -32,7 +32,7 @@ body {
   border-style: solid;
   border-color: transparent transparent transparent #456eb9;
 }
-/* line 38, _css-arrow.sass */
+/* line 33, _css-arrow.sass */
 .arrow.east:after {
   content: "\00a0";
   display: block;
@@ -51,7 +51,7 @@ body {
   margin-bottom: 50px;
   position: relative;
 }
-/* line 13, _css-arrow.sass */
+/* line 12, _css-arrow.sass */
 .arrow.south:before {
   content: "\00a0";
   display: block;
@@ -65,7 +65,7 @@ body {
   border-style: solid;
   border-color: #456eb9 transparent transparent transparent;
 }
-/* line 38, _css-arrow.sass */
+/* line 33, _css-arrow.sass */
 .arrow.south:after {
   content: "\00a0";
   display: block;
@@ -84,7 +84,7 @@ body {
   margin-top: -15px;
   position: relative;
 }
-/* line 13, _css-arrow.sass */
+/* line 12, _css-arrow.sass */
 .arrow.north:before {
   content: "\00a0";
   display: block;
@@ -98,7 +98,7 @@ body {
   border-style: solid;
   border-color: transparent transparent #456eb9 transparent;
 }
-/* line 38, _css-arrow.sass */
+/* line 33, _css-arrow.sass */
 .arrow.north:after {
   content: "\00a0";
   display: block;
@@ -118,7 +118,7 @@ body {
   width: 450px;
   position: relative;
 }
-/* line 13, _css-arrow.sass */
+/* line 12, _css-arrow.sass */
 .arrow.west:before {
   content: "\00a0";
   display: block;
@@ -132,7 +132,7 @@ body {
   border-style: solid;
   border-color: transparent #456eb9 transparent transparent;
 }
-/* line 38, _css-arrow.sass */
+/* line 33, _css-arrow.sass */
 .arrow.west:after {
   content: "\00a0";
   display: block;
@@ -152,7 +152,7 @@ body {
   margin-right: 50px;
   position: relative;
 }
-/* line 13, _css-arrow.sass */
+/* line 12, _css-arrow.sass */
 .arrow.borderless:before {
   content: "\00a0";
   display: block;
@@ -166,7 +166,7 @@ body {
   border-style: solid;
   border-color: transparent transparent transparent #456eb9;
 }
-/* line 38, _css-arrow.sass */
+/* line 33, _css-arrow.sass */
 .arrow.borderless:after {
   content: "\00a0";
   display: block;
@@ -192,7 +192,7 @@ blockquote {
   margin-left: 0;
   position: relative;
 }
-/* line 13, _css-arrow.sass */
+/* line 12, _css-arrow.sass */
 blockquote:before {
   content: "\00a0";
   display: block;
@@ -206,7 +206,7 @@ blockquote:before {
   border-style: solid;
   border-color: #333333 transparent transparent transparent;
 }
-/* line 38, _css-arrow.sass */
+/* line 33, _css-arrow.sass */
 blockquote:after {
   content: "\00a0";
   display: block;


### PR DESCRIPTION
While compiling the examples with Rake I got the following warning:

DEPRECATION WARNING:
On line 11, character 75 of '/home/steven/Checkouts/sass-recipes/css-arrow/_css-arrow.sass'
Setting mixin argument defaults with = has been deprecated and will be removed in version 3.2.
Use "$width: 10px" instead.

This commit fixes the deprecation warning.
